### PR TITLE
Allow missing `new`.

### DIFF
--- a/core-object.js
+++ b/core-object.js
@@ -12,10 +12,18 @@ CoreObject.prototype.constructor = CoreObject;
 
 CoreObject.extend = function(options) {
   var constructor = this;
+
   function Class() {
     var args = new Array(arguments.length);
     for (var i = 0, l = args.length; i < l; i++) {
       args[i] = arguments[i];
+    }
+
+    if (!(this instanceof Class)) {
+      var instance = new MissingNew();
+      Class.apply(instance, args);
+
+      return instance;
     }
 
     constructor.apply(this, args);
@@ -30,6 +38,9 @@ CoreObject.extend = function(options) {
   assign(Class.prototype, options);
   Class.prototype.constructor = Class;
   Class.prototype._super = constructor.prototype;
+
+  function MissingNew() {};
+  MissingNew.prototype = Class.prototype;
 
   return Class;
 };

--- a/tests/core-object-test.js
+++ b/tests/core-object-test.js
@@ -78,6 +78,16 @@ describe('core-object.js', function() {
     assert(barCalled);
   });
 
+  it('child classes can be instantiated without new', function() {
+    var called = false;
+
+    var Klass = CoreObject.extend();
+
+    var instance = Klass();
+
+    assert(instance instanceof Klass);
+  });
+
   describe('_super', function() {
     it('an extended class can call methods on its parents constructor via _super.methodName', function() {
       var fooCalled = false;


### PR DESCRIPTION
This change allows instantiation of core-object classes without the `new` keyword. Generally, this is not a good idea, but there are cases where `new` is slightly more "annoying".

My specific use case is the common practice in the `Brocfile.js` of calling the constructor directly (ala `pickFiles`) instead of calling `new PickFiles`.  I would like to make it SUPER easy to make a new [broccoli-caching-writer](https://github.com/rwjblue/broccoli-caching-writer) subclass, while core-object makes it a SUPER simple change/addition it requires the end consumers to use `new` in their `Brocfiles.js` (which is a fairly big departure from most examples).
