### PR TITLE
Fix calling of entire 'init' chain

### DIFF
--- a/core-object.js
+++ b/core-object.js
@@ -12,9 +12,9 @@ CoreObject.extend = function(options) {
   var constructor = this;
 
   function Class() {
-    CoreObject.apply(this, arguments);
-    if (this.init) {
-      this.init.apply(this, arguments);
+    constructor.apply(this, arguments);
+    if (options && options.init) {
+      options.init.apply(this, arguments);
     }
   }
 

--- a/tests/core-object-test.js
+++ b/tests/core-object-test.js
@@ -94,6 +94,33 @@ describe('core-object.js', function() {
 
       assert.equal(called, 1);
     });
+
+    it('super chain of inits is called', function() {
+      var called = '';
+
+      var Klass1 = CoreObject.extend({
+        init: function(){
+          called += '1';
+        }
+      });
+
+      var Klass2 = Klass1.extend({
+        init: function(){
+          called += '2';
+        }
+      });
+
+      var Klass3 = Klass2.extend({
+        init: function(){
+          called += '3';
+        }
+      });
+
+      var instance = new Klass3();
+
+      assert.equal(called, '123');
+    });
+
   });
 
   describe('_super', function() {


### PR DESCRIPTION
This fixes a regression introduced in 7ca47b1fc09d8f59e065e114c0d40dcd5dd59931.

Unit test included. If somebody gives me a "LGTM" I can merge and release.
