### PR TITLE
Support `this._super.foo`

### DIFF
--- a/lib/assign-properties.js
+++ b/lib/assign-properties.js
@@ -1,8 +1,16 @@
-function giveMethodSuper(name, target, fn) {
+function giveMethodSuper(superclass, name, fn) {
+  var superFn = superclass[name];
+
+  if (typeof superFn !== 'function') {
+    superFn = function() {};
+  }
+
+  // jgwhite: Compatibility hack to allow `this._super.foo`
+  superFn[name] = superFn;
+
   return function() {
     var previous = this._super;
-    this._super = target;
-    this._super[name] = target;
+    this._super = superFn;
     var ret = fn.apply(this, arguments);
     this._super = previous;
     return ret;
@@ -34,13 +42,8 @@ function assignProperties(target, options) {
   for (var key in options) {
     value = options[key];
 
-    if (typeof value === 'function' &&
-        hasSuper(value)) {
-      if (typeof target[key] === 'function') {
-        target[key] = giveMethodSuper(key, target[key], value);
-      } else {
-        target[key] = giveMethodSuper(key, function() { }, value);
-      }
+    if (typeof value === 'function' && hasSuper(value)) {
+      target[key] = giveMethodSuper(target, key, value);
     } else {
       target[key] = value;
     }

--- a/lib/assign-properties.js
+++ b/lib/assign-properties.js
@@ -1,7 +1,8 @@
-function giveMethodSuper(target, fn) {
+function giveMethodSuper(name, target, fn) {
   return function() {
     var previous = this._super;
     this._super = target;
+    this._super[name] = target;
     var ret = fn.apply(this, arguments);
     this._super = previous;
     return ret;
@@ -36,9 +37,9 @@ function assignProperties(target, options) {
     if (typeof value === 'function' &&
         hasSuper(value)) {
       if (typeof target[key] === 'function') {
-        target[key] = giveMethodSuper(target[key], value);
+        target[key] = giveMethodSuper(key, target[key], value);
       } else {
-        target[key] = giveMethodSuper(function() { }, value);
+        target[key] = giveMethodSuper(key, function() { }, value);
       }
     } else {
       target[key] = value;

--- a/lib/assign-properties.js
+++ b/lib/assign-properties.js
@@ -6,7 +6,11 @@ function giveMethodSuper(superclass, name, fn) {
   }
 
   // jgwhite: Compatibility hack to allow `this._super.foo`
-  superFn[name] = superFn;
+  superFn[name] = function() {
+    console.warn('DEPRECATION: Calling this._super.' + name +
+                 ' is deprecated. Please use this._super(args).');
+    return superFn.apply(this, arguments);
+  }
 
   return function() {
     var previous = this._super;

--- a/tests/assign-properties-test.js
+++ b/tests/assign-properties-test.js
@@ -71,4 +71,36 @@ describe('assignProperties', function() {
       assert.equal(target.a(), 6);
     });
   });
+
+  describe('super.methodName', function() {
+    it('supported with deprecation notice', function() {
+      var prev = console.warn;
+      var warning;
+
+      console.warn = function(msg) {
+        warning = msg;
+      }
+
+      var target = {
+        a: function() {
+          return 1;
+        }
+      };
+
+      var input = {
+        a: function() {
+          return this._super.a.apply(this) + 5;
+        }
+      };
+
+      assignProperties(target, input);
+
+      assert.equal(target.a(), 6);
+      assert.equal(warning,
+        'DEPRECATION: Calling this._super.a is deprecated. ' +
+        'Please use this._super(args).');
+
+      console.warn = prev;
+    });
+  });
 });


### PR DESCRIPTION
Adds an interim hack to maintain compatibility with `this._super.foo`.