### PR TITLE
[BUGFIX release] Update deprecation wording in init.

### DIFF
--- a/core-object.js
+++ b/core-object.js
@@ -40,25 +40,18 @@ CoreObject.extend = function(options) {
   if (options) {
     if (shouldCallSuper(options.init)) {
 
+      // this._super.init && is to make sure that the deprecation message
+      // works for people who are writing addons supporting before 2.6.
+      deprecation(
+        'The addon `' + options.name + '` is overriding init without calling this._super. ' +
+          'This behaviour is deprecated. ' +
+          'This means that addon\'s author needs to update it calling `this._super.init && this._super.init.apply(this, arguments)` ' +
+          'and release a new version. ' +
+          'Do not worry, ember-cli is working normally.'
+      );
       if (hasArgs(options.init)) {
-        deprecation(
-          'The addon `' + options.name + '` is overriding init without calling this._super. ' +
-            'This behaviour is deprecated. ' +
-            'This means that addon\'s author needs to update it calling `this._super()` and release a new version. ' +
-            'Do not worry, ember-cli is working normally.'
-        );
         options.init = forceSuperWithoutApply(options.init);
       } else {
-
-        // this._super.init && is to make sure that the deprecation message
-        // works for people who are writing addons supporting before 2.6.
-        deprecation(
-          'The addon `' + options.name + '` is overriding init without calling this._super. ' +
-            'This behaviour is deprecated. ' +
-            'This means that addon\'s author needs to update it calling `this._super.init && this._super.init.apply(this, arguments)` ' +
-            'and release a new version. ' +
-            'Do not worry, ember-cli is working normally.'
-        );
         options.init = forceSuper(options.init);
       }
     }

--- a/core-object.js
+++ b/core-object.js
@@ -44,7 +44,7 @@ CoreObject.extend = function(options) {
         deprecation(
           'The addon `' + options.name + '` is overriding init without calling this._super. ' +
             'This behaviour is deprecated. ' +
-            'This means that addon\'s writer needs to update it calling `this._super()` and release a new version. ' +
+            'This means that addon\'s author needs to update it calling `this._super()` and release a new version. ' +
             'Do not worry, ember-cli is working normally.'
         );
         options.init = forceSuperWithoutApply(options.init);
@@ -55,7 +55,7 @@ CoreObject.extend = function(options) {
         deprecation(
           'The addon `' + options.name + '` is overriding init without calling this._super. ' +
             'This behaviour is deprecated. ' +
-            'This means that addon\'s writer needs to update it calling `this._super.init && this._super.init.apply(this, arguments)` ' +
+            'This means that addon\'s author needs to update it calling `this._super.init && this._super.init.apply(this, arguments)` ' +
             'and release a new version. ' +
             'Do not worry, ember-cli is working normally.'
         );

--- a/core-object.js
+++ b/core-object.js
@@ -42,8 +42,10 @@ CoreObject.extend = function(options) {
 
       if (hasArgs(options.init)) {
         deprecation(
-          'Overriding init without calling this._super is deprecated. ' +
-            'Please call this._super(), addon: `' + options.name + '`'
+          'The addon `' + options.name + '` is overriding init without calling this._super. ' +
+            'This behaviour is deprecated. ' +
+            'This means that addon\'s writer needs to update it calling `this._super()` and release a new version. ' +
+            'Do not worry, ember-cli is working normally.'
         );
         options.init = forceSuperWithoutApply(options.init);
       } else {
@@ -51,8 +53,11 @@ CoreObject.extend = function(options) {
         // this._super.init && is to make sure that the deprecation message
         // works for people who are writing addons supporting before 2.6.
         deprecation(
-          'Overriding init without calling this._super is deprecated. ' +
-            'Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `' + options.name + '`'
+          'The addon `' + options.name + '` is overriding init without calling this._super. ' +
+            'This behaviour is deprecated. ' +
+            'This means that addon\'s writer needs to update it calling `this._super.init && this._super.init.apply(this, arguments)` ' +
+            'and release a new version. ' +
+            'Do not worry, ember-cli is working normally.'
         );
         options.init = forceSuper(options.init);
       }


### PR DESCRIPTION
The deprecation message has been rephrase to emphasize final users don't need to call `this._super`.

Though the deprecation is still there, I hope rewording the message would prevent new users from panicking when receiving the deprecation warning.

It is easier to update the message than to follow [the other steps I suggested in the issue](https://github.com/ember-cli/ember-cli/issues/5973#issuecomment-226992055), so it seems like a feasible first step just in case ember-cli-release cannot be easily fixed.
