### PR TITLE
add support for property descriptors

### DIFF
--- a/lib/assign-properties.js
+++ b/lib/assign-properties.js
@@ -1,4 +1,6 @@
+require('./get-own-property-descriptors');
 var deprecation = require('./deprecation');
+
 
 function setPrototypeOf(obj, proto) {
   Object.setPrototypeOf ? Object.setPrototypeOf(obj, proto) : obj.__proto__ = proto;
@@ -6,6 +8,14 @@ function setPrototypeOf(obj, proto) {
 
 function getPrototypeOf(obj, proto) {
   return Object.getPrototypeOf ? Object.getPrototypeOf(obj) : obj.__proto__;
+}
+
+function hasGetter(descriptor) {
+  return descriptor.hasOwnProperty('get') && descriptor.get !== undefined;
+}
+
+function hasSetter(descriptor) {
+  return descriptor.hasOwnProperty('set') && descriptor.set !== undefined;
 }
 
 function giveMethodSuper(superclass, name, fn) {
@@ -54,17 +64,42 @@ if (sourceAvailable) {
   }
 }
 
+function mergeDescriptors(descriptor, targetDescriptor) {
+  if (descriptor.hasOwnProperty('value') || !targetDescriptor) {
+    return descriptor;
+  }
+
+  if ( !hasGetter(descriptor) && hasGetter(targetDescriptor) ) {
+    descriptor.get = targetDescriptor.get;
+  }
+
+  if ( !hasSetter(descriptor) && hasSetter(targetDescriptor) ) {
+    descriptor.set = targetDescriptor.set;
+  }
+
+  return descriptor;
+}
+
 function assignProperties(target, options) {
-  var value;
+  var optionDescriptors  = Object.getOwnPropertyDescriptors(options),
+      targetDescriptors  = Object.getOwnPropertyDescriptors(getPrototypeOf(target)),
+      propertiesToDefine = {},
+      value, descriptor, targetDescriptor;
 
   for (var key in options) {
-    value = options[key];
+    descriptor = optionDescriptors[key];
+    value = descriptor.value;
 
     if (typeof value === 'function' && hasSuper(value)) {
       target[key] = giveMethodSuper(getPrototypeOf(target), key, value);
     } else {
-      target[key] = value;
+      targetDescriptor = targetDescriptors[key];
+      propertiesToDefine[key] = mergeDescriptors(descriptor, targetDescriptor);
     }
+  }
+
+  if (Object.keys(propertiesToDefine).length) {
+    Object.defineProperties(target, propertiesToDefine);
   }
 }
 

--- a/lib/get-own-property-descriptors.js
+++ b/lib/get-own-property-descriptors.js
@@ -1,0 +1,27 @@
+// Polyfill for Object.getOwnPropertyDescriptors based off TC-39's proposal
+// Link: https://github.com/tc39/proposal-object-getownpropertydescriptors
+
+if (!Object.hasOwnProperty('getOwnPropertyDescriptors')) {
+  Object.defineProperty(
+    Object,
+    'getOwnPropertyDescriptors',
+    {
+      configurable: true,
+      writable: true,
+      value: function getOwnPropertyDescriptors(object) {
+        return Object.keys(object).reduce(function(descriptors, key) {
+          return Object.defineProperty(
+            descriptors,
+            key,
+            {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value: Object.getOwnPropertyDescriptor(object, key)
+            }
+          );
+        }, {});
+      }
+    }
+  );
+}

--- a/tests/core-object-test.js
+++ b/tests/core-object-test.js
@@ -70,6 +70,59 @@ describe('core-object.js', function() {
     assert(barCalled);
   });
 
+  it('an extended class can be extended with ES5 property descriptors', function() {
+    var Klass1 = CoreObject.extend({
+      bar: 'bar',
+
+      get foo() {
+        return this.bar;
+      },
+
+      set foo(value) {
+        this.bar = value;
+        return value;
+      }
+    });
+
+    var Klass2 = Klass1.extend({
+      baz: 'baz',
+
+      get foo() {
+        return this.baz;
+      }
+    });
+
+    var Klass3 = Klass1.extend({
+      get foo() {
+        return this.bar + ' and bye!';
+      },
+
+      set foo(value) {
+        return this.bar = value + ' hi';
+      }
+    });
+
+    var obj1 = new Klass1();
+    var obj2 = new Klass2();
+    var obj3 = new Klass3();
+
+    assert(obj1.foo === 'bar');
+    assert(obj2.foo === 'baz');
+    assert(obj3.foo === 'bar and bye!');
+
+    obj1.foo = 'foobar';
+    assert(obj1.foo === 'foobar');
+    assert(obj1.bar === 'foobar');
+
+    obj2.foo = 'foobarbaz';
+    assert(obj2.foo === 'baz');
+    assert(obj2.bar === 'foobarbaz');
+
+    obj3.foo = 'qux';
+    assert(obj3.foo === 'qux hi and bye!');
+    assert(obj3.bar === 'qux hi');
+  });
+
   describe('init', function(){
 
     it('init is called with the arguments to new', function() {


### PR DESCRIPTION
closes #29 

Node Benchmarks: (couldn't get browser ones to work)

Before:

```
core-object/create (0)  x 1,179,436 ops/sec ±1.03% (84 runs sampled)
core-object/create (1)  x 728,570 ops/sec ±3.19% (79 runs sampled)
core-object/create (5)  x 791,077 ops/sec ±1.68% (76 runs sampled)
core-object/create (default init) (0)  x 12,368,014 ops/sec ±2.75% (80 runs sampled)
core-object/create (default init) (1)  x 2,472,344 ops/sec ±1.45% (76 runs sampled)
core-object/create (default init) (5)  x 491,107 ops/sec ±1.17% (82 runs sampled)
uberproto/create (0)  x 2,525,956 ops/sec ±1.15% (81 runs sampled)
uberproto/create (1)  x 2,528,991 ops/sec ±1.17% (82 runs sampled)
uberproto/create (5)  x 2,337,608 ops/sec ±2.90% (78 runs sampled)
raw/create (0)  x 20,691,590 ops/sec ±1.97% (78 runs sampled)
raw/create (1)  x 25,702,769 ops/sec ±1.73% (77 runs sampled)
raw/create (5)  x 21,648,817 ops/sec ±1.62% (75 runs sampled)
esnext/create (0)  x 18,154,432 ops/sec ±2.68% (74 runs sampled)
esnext/create (1)  x 22,432,550 ops/sec ±2.52% (75 runs sampled)
esnext/create (5)  x 19,709,753 ops/sec ±1.95% (77 runs sampled)
klass/create (0)  x 5,085,804 ops/sec ±1.84% (77 runs sampled)
klass/create (1)  x 4,942,793 ops/sec ±1.64% (79 runs sampled)
klass/create (5)  x 4,940,045 ops/sec ±1.64% (79 runs sampled)
backbone-metal/create (0)  x 4,740,320 ops/sec ±7.70% (63 runs sampled)
backbone-metal/create (1)  x 2,288,825 ops/sec ±2.54% (81 runs sampled)
backbone-metal/create (5)  x 2,237,392 ops/sec ±2.39% (76 runs sampled)
core-object/extend (1)  x 1,157,571 ops/sec ±1.61% (78 runs sampled)
core-object/extend (5)  x 371,967 ops/sec ±1.89% (79 runs sampled)
uberproto/extend (1)  x 170,055 ops/sec ±1.21% (76 runs sampled)
uberproto/extend (5)  x 53,705 ops/sec ±1.54% (78 runs sampled)
klass/extend (1)  x 181,904 ops/sec ±5.50% (58 runs sampled)
klass/extend (5)  x 91,839 ops/sec ±5.21% (66 runs sampled)
backbone-metal/extend (1)  x 145,464 ops/sec ±3.24% (71 runs sampled)
backbone-metal/extend (5)  x 74,263 ops/sec ±3.25% (71 runs sampled)
```

After:

```
core-object/create (0)  x 1,128,621 ops/sec ±1.12% (82 runs sampled)
core-object/create (1)  x 751,751 ops/sec ±1.87% (84 runs sampled)
core-object/create (5)  x 730,235 ops/sec ±1.23% (84 runs sampled)
core-object/create (default init) (0)  x 12,399,318 ops/sec ±1.10% (84 runs sampled)
core-object/create (default init) (1)  x 2,431,482 ops/sec ±1.62% (80 runs sampled)
core-object/create (default init) (5)  x 511,831 ops/sec ±1.21% (82 runs sampled)
uberproto/create (0)  x 2,486,342 ops/sec ±1.15% (83 runs sampled)
uberproto/create (1)  x 2,495,017 ops/sec ±1.22% (79 runs sampled)
uberproto/create (5)  x 2,382,672 ops/sec ±2.45% (79 runs sampled)
raw/create (0)  x 22,135,087 ops/sec ±1.55% (82 runs sampled)
raw/create (1)  x 26,974,420 ops/sec ±1.66% (77 runs sampled)
raw/create (5)  x 23,151,079 ops/sec ±1.56% (80 runs sampled)
esnext/create (0)  x 19,373,088 ops/sec ±2.28% (71 runs sampled)
esnext/create (1)  x 23,830,007 ops/sec ±1.62% (81 runs sampled)
esnext/create (5)  x 21,069,224 ops/sec ±1.74% (77 runs sampled)
klass/create (0)  x 5,189,756 ops/sec ±1.65% (81 runs sampled)
klass/create (1)  x 5,106,455 ops/sec ±1.65% (77 runs sampled)
klass/create (5)  x 5,170,719 ops/sec ±1.46% (63 runs sampled)
backbone-metal/create (0)  x 4,966,532 ops/sec ±6.08% (72 runs sampled)
backbone-metal/create (1)  x 2,359,407 ops/sec ±2.60% (79 runs sampled)
backbone-metal/create (5)  x 2,336,906 ops/sec ±2.28% (81 runs sampled)
core-object/extend (1)  x 434,122 ops/sec ±1.14% (85 runs sampled)
core-object/extend (5)  x 123,252 ops/sec ±1.40% (82 runs sampled)
uberproto/extend (1)  x 170,180 ops/sec ±1.95% (79 runs sampled)
uberproto/extend (5)  x 52,722 ops/sec ±1.42% (78 runs sampled)
klass/extend (1)  x 184,676 ops/sec ±4.89% (60 runs sampled)
klass/extend (5)  x 93,069 ops/sec ±4.48% (64 runs sampled)
backbone-metal/extend (1)  x 145,954 ops/sec ±3.44% (69 runs sampled)
backbone-metal/extend (5)  x 72,164 ops/sec ±4.36% (70 runs sampled)
```

extend is quite a bit slower, so might need to look at some optimizations somewhere (though create is the main piece we want performant).
