### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,12 @@ node_js:
   - "6"
   - "4"
   - "0.12"
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: glmcDFLoo0uafFDyZhyS2tEueUx7QNDgNWCdFcE6G/c22yeHaC5O0dD2G8gw+Ogx+83rmmN3U2dD7waN84PhumUV4x6jzFzNnU86gaU3dZg9/+uSSPlYotLuYUD4NOHgxxinjjH7h/Jw8Tw6np7lxIojO+iRpYnK+E8rDrtImNQ=
+  on:
+    tags: true
+    repo: ember-cli/core-object


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

`git owner add ember-cli` is still needed, because I didn't have the NPM owner bit to do it myself.

/cc @nathanhammond @stefanpenner @rwjblue