### PR TITLE
Add mixin function with super support for pojos

### DIFF
--- a/core-object.js
+++ b/core-object.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assignProperties = require('./lib/assign-properties');
+const mixin = require('./lib/mixin');
 const deprecation = require('./lib/deprecation');
 
 class CoreObject {
@@ -43,6 +44,10 @@ class CoreObject {
     }
 
     return Class;
+  }
+
+  static mixin(target, mixinObj) {
+    return mixin(target, mixinObj);
   }
 }
 

--- a/lib/mixin.js
+++ b/lib/mixin.js
@@ -1,0 +1,33 @@
+'use strict';
+
+function arrayUnion(a, b) {
+  let map = {};
+  let i = 0;
+  for (; i < a.length; i++) {
+    map[a[i]] = true;
+  }
+  for (i = 0; i < b.length; i++) {
+    map[b[i]] = true;
+  }
+  return Object.keys(map);
+}
+
+module.exports = function mixin(target, parent) {
+  arrayUnion(Object.keys(target), Object.keys(parent)).forEach(function(key) {
+    const targetValue = target[key];
+    const parentValue = parent[key];
+    
+    // If both the object and the parent define the same key as a function
+    if (typeof targetValue === 'function' && typeof parentValue === 'function') {
+      if (targetValue.toString().indexOf('_super') > -1) {
+        target[key] = function mixinSuperWrapper() {
+          this._super = parent;
+          return targetValue.apply(this, arguments);
+        };
+      }
+    } else if (!(key in target)) {
+      target[key] = parentValue;
+    }
+  });
+  return target;
+}

--- a/tests/mixin-test.js
+++ b/tests/mixin-test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const assert = require('assert');
+const CoreObject = require('../core-object');
+
+describe('mixin', function() {
+  it('noop', function() {
+    let target = {};
+    let mixinObj = {};
+
+    CoreObject.mixin(target, mixinObj);
+    assert.deepEqual(target, mixinObj);
+  });
+
+  it('target object wins during conflict', function() {
+    let target = { a: 2, c: [1]};
+    let mixinObj  = { a: 1, b: 2, c: []};
+
+    CoreObject.mixin(target, mixinObj);
+    assert.equal(target.a, 2);
+    assert.deepEqual(target.c, [1]);
+    assert.equal(target.b, 2);
+  });
+
+  it('falsy value on target still wins during conflict', function() {
+    let target = { a: 1, b: null };
+    let mixinObj  = { b: 2 };
+
+    CoreObject.mixin(target, mixinObj);
+    assert.equal(target.b, null);
+  });
+
+  it('undefined value on target still wins during conflict', function() {
+    let target = { a: 1, b: undefined };
+    let mixinObj  = { b: 2 };
+
+    CoreObject.mixin(target, mixinObj);
+    assert.equal(target.b, undefined);
+  });
+
+  it('deleted value on target can be overwritten', function() {
+    let target = { a: 1, b: 11 };
+    let mixinObj  = { b: 2 };
+
+    delete target.b;
+
+    CoreObject.mixin(target, mixinObj);
+    assert.equal(target.b, 2);
+  });
+
+  describe('super', function() {
+    it('can call super', function() {
+      let mixinObj = {
+        number: function() {
+          return 2;
+        }
+      };
+
+      let target = {
+        number: function() {
+          return this._super.number() + 1;
+        }
+      }
+
+      CoreObject.mixin(target, mixinObj);
+
+      assert.equal(target.number(), 3);
+    });
+
+    it('super fuction has correct context', function() {
+      let mixinObj = {
+        anchor: 3,
+        number: function() {
+          return this.anchor;
+        }
+      };
+
+      let target = {
+        anchor: 10,
+        number: function() {
+          return this._super.number() + 10;
+        }
+      }
+
+      CoreObject.mixin(target, mixinObj);
+
+      assert.equal(target.number(), 13);
+    });
+
+    it('target fuction has correct context', function() {
+      let mixinObj = {
+        anchor: 3,
+        number: function() {
+          return this.anchor;
+        }
+      };
+
+      let target = {
+        anchor: 10,
+        number: function() {
+          return this._super.number() + this.anchor;
+        }
+      }
+
+      CoreObject.mixin(target, mixinObj);
+
+      assert.equal(target.number(), 13);
+    });
+
+    it('target fuction has correct context', function() {
+      let mixinObj = {
+        anchor: 3,
+        number: function() {
+          return this.anchor;
+        }
+      };
+
+      let target = {
+        anchor: 10,
+        number: function() {
+          return this._super.number() + this.anchor;
+        }
+      }
+
+      CoreObject.mixin(target, mixinObj);
+
+      assert.equal(target.number(), 13);
+    });
+  });
+});


### PR DESCRIPTION
Allow mixins with super using simple pojos (with effectively no prototype). Not sure if a static method on `CoreObject` is the ideal way to expose this function.

cc @stefanpenner 